### PR TITLE
check if session is valid before cache

### DIFF
--- a/src/CognitoAuth.js
+++ b/src/CognitoAuth.js
@@ -314,8 +314,10 @@
       } else {
         this.signInUserSession.setRefreshToken(refreshToken);
       }
-      this.cacheTokensScopes();
-      return this.userhandler.onSuccess(this.signInUserSession);
+      if(this.signInUserSession.isValid()){
+        this.cacheTokensScopes();
+        return this.userhandler.onSuccess(this.signInUserSession);
+      }
     }
   
     /**


### PR DESCRIPTION
calling `parseCognitoWebResponse(window.location.href)` (like in the [sample](https://github.com/aws/amazon-cognito-auth-js/blob/master/sample/index.html)) will throw an error if the url does contain any arbitrary fragment (e.g. `https://domain.com/signin-callback.html#foo`)

```
aws-cognito-sdk.js:11656 Uncaught TypeError: First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object.
    at fromObject (aws-cognito-sdk.js:11656)
    at from (aws-cognito-sdk.js:11505)
    at new Buffer (aws-cognito-sdk.js:11482)
    at Object.decode64 [as decode] (aws-cognito-sdk.js:7825)
    at CognitoAccessToken.getUsername (amazon-cognito-auth.js:221)
    at CognitoAuth.cacheTokensScopes (amazon-cognito-auth.js:1267)
    at CognitoAuth.getTokenQueryParameter (amazon-cognito-auth.js:1198)
    at CognitoAuth.parseCognitoWebResponse (amazon-cognito-auth.js:1136)
    at (index):40
```