### PR TITLE
 Fixed tokens being empty strings

### DIFF
--- a/src/CognitoAuth.js
+++ b/src/CognitoAuth.js
@@ -61,12 +61,12 @@
       this.RedirectUriSignIn = RedirectUriSignIn;
       this.RedirectUriSignOut = RedirectUriSignOut;
       this.IdentityProvider = IdentityProvider;
-      this.signInUserSession = new CognitoAuthSession();
       this.responseType = this.getCognitoConstants().TOKEN;
       this.storage = new StorageHelper().getStorage();
-      this.signInUserSession.setTokenScopes(tokenScopes);
       this.username = this.getLastUser();
       this.userPoolId = UserPoolId;
+      this.signInUserSession = this.getCachedSession();
+      this.signInUserSession.setTokenScopes(tokenScopes);
   
       /**
        * By default, AdvancedSecurityDataCollectionFlag is set to true, if no input value is provided.

--- a/src/CognitoAuth.js
+++ b/src/CognitoAuth.js
@@ -777,7 +777,6 @@
      * @returns {boolean} userSignedIn 
      */
     isUserSignedIn() {
-     return ((this.getCachedSession() != null && this.getCachedSession().isValid() || 
-       this.signInUserSession != null && this.signInUserSession.isValid()));
+      return (this.signInUserSession != null && this.signInUserSession.isValid()) || this.getCachedSession().isValid();
     }
   }


### PR DESCRIPTION
The current constructor is setting `this.signInUserSession` to a new instance of `CognitoAuthSession`.  When refreshing the browser of a single page application, `getSignInUserSession().getIdToken().getJwtToken()` returns an empty string (`""`).

The changes proposed fix this issue.