### PR TITLE
In parseCognitoWebResponse(), added onFailure() callback for code response type

### DIFF
--- a/src/CognitoAuth.js
+++ b/src/CognitoAuth.js
@@ -272,6 +272,9 @@
           response,
           this.getCognitoConstants().QUESTIONMARK
         );
+        if (map.has(this.getCognitoConstants().ERROR)) {
+          return this.userhandler.onFailure(map.get(this.getCognitoConstants().ERROR_DESCRIPTION));
+        }
         this.getCodeQueryParameter(map);
       } else if (httpRequestResponse.indexOf(this.getCognitoConstants().POUNDSIGN) > -1) { // for token type
         map = this.getQueryParameters(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In parseCognitoWebResponse(), onFailure() callback is needed for both code response type and token response type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
