### PR TITLE
Removing needless xhr.open call that is handled in if/else logic, and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ import {CognitoAuth} from 'amazon-cognito-auth-js';
 */
 var authData = {
 	ClientId : '<TODO: add ClientId>', // Your client id here
-	AppWebDomain : '<TODO: add App Web Domain>',
+	AppWebDomain : '<TODO: add App Web Domain>', // Exclude protocol (e.g. 'my-app.auth.us-west-2.amazoncognito.com')
 	TokenScopesArray : ['<TODO: add scope array>'], // e.g.['phone', 'email', 'profile','openid', 'aws.cognito.signin.user.admin'],
 	RedirectUriSignIn : '<TODO: add redirect url when signed in>',
 	RedirectUriSignOut : '<TODO: add redirect url when signed out>',

--- a/src/CognitoAuth.js
+++ b/src/CognitoAuth.js
@@ -568,7 +568,6 @@
      */
     createCORSRequest(method, url) {
       let xhr = new XMLHttpRequest();
-      xhr.open(method, url, true);
       if (this.getCognitoConstants().WITHCREDENTIALS in xhr) {
         // XHR for Chrome/Firefox/Opera/Safari.
         xhr.open(method, url, true);


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-js/issues/1143

*Description of changes:*
1) Removing needless `xhr.open` call found here: https://github.com/aws/amazon-cognito-auth-js/blob/1ea0f1d9282201f31411ac87b8a96a244793c1f4/src/CognitoAuth.js#L571 

    It occurs once on function call, and then again in the first if clause if conditions are met. 

    The second if else changes the logic of xhr, so this seems needless. Removing it solves the error `[Error: Cannot open, already sending]`. 

2) Adding a brief comment in the README, as it was not clear to remove the protocol in the AppWebDomain parameter, which was causing `https://https://` as the SDK prepends the protocol to the request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
