### PR TITLE
Support URL with Hash based routing

### DIFF
--- a/src/CognitoAuth.js
+++ b/src/CognitoAuth.js
@@ -259,12 +259,13 @@
   
     /**
      * @param {string} httpRequestResponse the http request response
+     * @param {boolean} isHashBasedUrl true if the url is made with hash routing
      * @returns {void}
      * Parse the http request response and proceed according to different response types.
      */
-    parseCognitoWebResponse(httpRequestResponse) {
+    parseCognitoWebResponse(httpRequestResponse,isHashBasedUrl) {
       let map;
-      if (httpRequestResponse.indexOf(this.getCognitoConstants().QUESTIONMARK) > -1) { // for code type
+      if (isHashBasedUrl || httpRequestResponse.indexOf(this.getCognitoConstants().QUESTIONMARK) > -1) { // for code type
         // this is to avoid a bug exists when sign in with Google or facebook
         // Sometimes the code will contain a poundsign in the end which breaks the parsing
         const response = (httpRequestResponse.split(this.getCognitoConstants().POUNDSIGN))[0];


### PR DESCRIPTION
*Issue https://github.com/aws/amazon-cognito-auth-js/issues/87*

*Description of changes:*

`parseCognitoWebResponse` assumes tjat hashes are always stand for query parameters, and didn't take into considuration that this may be just hash based routing.
add another paramter to indicate the difference.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
