### PR TITLE
Set jwtToken to null instead of blank string

### DIFF
--- a/src/CognitoAccessToken.js
+++ b/src/CognitoAccessToken.js
@@ -23,7 +23,7 @@ export default class CognitoAccessToken {
    */
   constructor(AccessToken) {
     // Assign object
-    this.jwtToken = AccessToken || '';
+    this.jwtToken = AccessToken || null;
     this.payload = this.decodePayload();
   }
 


### PR DESCRIPTION
getUsername() and getExpiration() throws error, when AccessToken is blank. In constructor, jwtToken should be set to null to avoid this error.

*Issue #, if available:*

*Description of changes:*

- Updated `constructor()` in `src/CognitoAccessToken.js` to set `jwtToken` property to `null` instead of empty string when `AccessToken` is not available.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
